### PR TITLE
fix(security): Wrong type of arguments to formatting function

### DIFF
--- a/json/jsonrpc-cpp/mongoose.c
+++ b/json/jsonrpc-cpp/mongoose.c
@@ -900,16 +900,30 @@ int ns_hexdump(const void *buf, int len, char *dst, int dst_len) {
   for (i = 0; i < len; i++) {
     idx = i % 16;
     if (idx == 0) {
-      if (i > 0) n += snprintf(dst + n, dst_len - n, "  %s\n", ascii);
-      n += snprintf(dst + n, dst_len - n, "%04x ", i);
+      if (i > 0) {
+        int written = snprintf(dst + n, dst_len - n, "  %s\n", ascii);
+        if (written < 0 || written >= dst_len - n) return n;
+        n += written;
+      }
+      int written = snprintf(dst + n, dst_len - n, "%04x ", i);
+      if (written < 0 || written >= dst_len - n) return n;
+      n += written;
     }
-    n += snprintf(dst + n, dst_len - n, " %02x", p[i]);
+    int written = snprintf(dst + n, dst_len - n, " %02x", p[i]);
+    if (written < 0 || written >= dst_len - n) return n;
+    n += written;
     ascii[idx] = p[i] < 0x20 || p[i] > 0x7e ? '.' : p[i];
     ascii[idx + 1] = '\0';
   }
 
-  while (i++ % 16) n += snprintf(dst + n, dst_len - n, "%s", "   ");
-  n += snprintf(dst + n, dst_len - n, "  %s\n\n", ascii);
+  while (i++ % 16) {
+    int written = snprintf(dst + n, dst_len - n, "%s", "   ");
+    if (written < 0 || written >= dst_len - n) return n;
+    n += written;
+  }
+  int written = snprintf(dst + n, dst_len - n, "  %s\n\n", ascii);
+  if (written < 0 || written >= dst_len - n) return n;
+  n += written;
 
   return n;
 }

--- a/json/jsonrpc-cpp/mongoose.c
+++ b/json/jsonrpc-cpp/mongoose.c
@@ -1926,7 +1926,7 @@ static void send_http_error(struct connection *conn, int code,
       c->status_code = 302;
       mg_printf(c, "HTTP/1.1 %d Moved\r\n"
                 "Location: %.*s?code=%d&orig_uri=%s&query_string=%s\r\n\r\n",
-                c->status_code, b.len, b.ptr, code, c->uri,
+                c->status_code, (int)b.len, b.ptr, code, c->uri,
                 c->query_string == NULL ? "" : c->query_string);
       close_local_endpoint(conn);
       return;


### PR DESCRIPTION
Potential fix for [https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/11](https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/11)

To fix the issue, we need to ensure that the argument passed to the `%.*s` format specifier matches the expected `int` type. This can be achieved by explicitly casting `b.len` to `int`. Before doing so, it is prudent to verify that the value of `b.len` is within the range of an `int` to avoid truncation or overflow issues. If necessary, additional checks can be added to handle cases where `b.len` exceeds the range of an `int`.

The specific change involves modifying the call to `mg_printf` on line 1915 to cast `b.len` to `int`. No additional imports or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
