### PR TITLE
fix(security): Wrong type of arguments to formatting function

### DIFF
--- a/json/jsonrpc-cpp/mongoose.c
+++ b/json/jsonrpc-cpp/mongoose.c
@@ -2697,7 +2697,7 @@ static int convert_uri_to_file_name(struct connection *conn, char *buf,
   if (root == NULL || root_len == 0) return 0;
 
   // Handle URL rewrites
-  mg_snprintf(buf, buf_len, "%.*s%s", root_len, root, uri);
+  mg_snprintf(buf, buf_len, "%.*s%s", (int) root_len, root, uri);
   rewrites = conn->server->config_options[URL_REWRITES];  // Re-initialize!
   while ((rewrites = next_option(rewrites, &a, &b)) != NULL) {
     if ((match_len = mg_match_prefix(a.ptr, a.len, uri)) > 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/10](https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/10)

To fix the issue, we need to ensure that the type of the argument passed to the `%.*s` format specifier matches the expected type (`int`). Since `root_len` is of type `size_t`, it should be explicitly cast to `int` when passed to the `mg_snprintf` function. This ensures that the format specifier and the argument are compatible, preventing undefined behavior.

The fix involves modifying the call to `mg_snprintf` on line 2700 to cast `root_len` to `int`. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
