### PR TITLE
fix(security): Potentially overflowing call to snprintf

### DIFF
--- a/json/jsonrpc-cpp/mongoose.c
+++ b/json/jsonrpc-cpp/mongoose.c
@@ -5186,10 +5186,15 @@ const char *mg_set_option(struct mg_server *server, const char *name,
         ns_sock_to_str(c->sock, buf2, sizeof(buf2),
                        memchr(vec.ptr, ':', vec.len) == NULL ? 2 : 3);
 
-        n += snprintf(buf + n, sizeof(buf) - n, "%s%s%s%s%s%s%s",
-                      n > 0 ? "," : "",
-                      use_ssl ? "ssl://" : "",
-                      buf2, cert[0] ? ":" : "", cert, ca[0] ? ":" : "", ca);
+        int written = snprintf(buf + n, sizeof(buf) - n, "%s%s%s%s%s%s%s",
+                                n > 0 ? "," : "",
+                                use_ssl ? "ssl://" : "",
+                                buf2, cert[0] ? ":" : "", cert, ca[0] ? ":" : "", ca);
+        if (written < 0 || (size_t)written >= sizeof(buf) - n) {
+          error_msg = "Buffer overflow detected";
+          break;
+        }
+        n += written;
       }
     }
     buf[sizeof(buf) - 1] = '\0';


### PR DESCRIPTION
Potential fix for [https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/5](https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/5)

To fix the issue, we need to validate the return value of `snprintf` and ensure that it does not exceed the remaining buffer size (`sizeof(buf) - n`). If the return value is negative or greater than or equal to the remaining size, the loop should terminate to prevent further incorrect behavior. This approach ensures that the buffer is used safely and avoids potential overflows or logical errors.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
