### PR TITLE
fix(security): Time-of-check time-of-use filesystem race condition

### DIFF
--- a/json/jsonrpc-cpp/mongoose.c
+++ b/json/jsonrpc-cpp/mongoose.c
@@ -3746,15 +3746,16 @@ static int remove_directory(const char *dir) {
   DIR *dirp;
 
   if ((dirp = opendir(dir)) == NULL) return 0;
+  int dir_fd = dirfd(dirp);
 
   while ((dp = readdir(dirp)) != NULL) {
     if (!strcmp(dp->d_name, ".") || !strcmp(dp->d_name, "..")) continue;
-    mg_snprintf(path, sizeof(path), "%s%c%s", dir, '/', dp->d_name);
-    stat(path, &st);
+    if (fstatat(dir_fd, dp->d_name, &st, 0) == -1) continue;
     if (S_ISDIR(st.st_mode)) {
+      mg_snprintf(path, sizeof(path), "%s%c%s", dir, '/', dp->d_name);
       remove_directory(path);
     } else {
-      remove(path);
+      unlinkat(dir_fd, dp->d_name, 0);
     }
   }
   closedir(dirp);


### PR DESCRIPTION
Potential fix for [https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/3](https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/3)

To fix the TOCTOU race condition, we should avoid relying on the file name after the `stat` check. Instead, we can use the `unlinkat` function, which operates on a file descriptor obtained from the directory. This ensures that the file being deleted is the same one that was checked. The `unlinkat` function is part of the POSIX standard and allows us to specify the directory file descriptor and the file name relative to that directory.

The changes involve:
1. Replacing the `stat` and `remove` calls with `fstatat` and `unlinkat`, respectively.
2. Using the directory file descriptor obtained from `opendir` to perform operations on files within the directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
