### PR TITLE
fix(security): Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/json/jsonrpc-cpp/mongoose.c
+++ b/json/jsonrpc-cpp/mongoose.c
@@ -5392,7 +5392,7 @@ static void iter2(struct ns_connection *nc, int ev, void *param) {
   (void) ev;
 
   //DBG(("%p [%s]", conn, msg));
-  if (sscanf(msg, "%p %n", &func, &n) && func != NULL && conn != NULL) {
+  if (sscanf(msg, "%p %n", &func, &n) == 1 && func != NULL && conn != NULL) {
     conn->mg_conn.callback_param = (void *) (msg + n);
     func(&conn->mg_conn, MG_POLL);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/1](https://github.com/MattKobayashi/eiskaltdcpp/security/code-scanning/1)

To fix the issue, the return value of `sscanf` should be explicitly checked against the expected number of matches (1 in this case). Additionally, the possibility of `EOF` should be handled to ensure robust error checking. This can be achieved by modifying the condition to verify that the return value is exactly 1, which indicates that the expected single item was successfully matched and assigned.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
